### PR TITLE
Support Colcon and Colcon Bundle

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -15,6 +15,7 @@ find_package(catkin REQUIRED COMPONENTS
   message_generation
 )
 
+catkin_python_setup()
 
 add_message_files(
   FILES
@@ -44,3 +45,23 @@ target_link_libraries(global_rrt_detector ${catkin_LIBRARIES})
 
 add_executable(local_rrt_detector src/local_rrt_detector.cpp src/functions.cpp src/mtrand.cpp)
 target_link_libraries(local_rrt_detector ${catkin_LIBRARIES})
+
+
+install(TARGETS global_rrt_detector local_rrt_detector
+  ARCHIVE DESTINATION ${CATKIN_PACKAGE_LIB_DESTINATION}
+  LIBRARY DESTINATION ${CATKIN_PACKAGE_LIB_DESTINATION}
+  RUNTIME DESTINATION ${CATKIN_PACKAGE_BIN_DESTINATION}
+)
+
+catkin_install_python(
+  PROGRAMS scripts/assigner.py
+           scripts/filter.py
+           scripts/frontier_opencv_detector.py
+           scripts/getfrontier.py
+           scripts/functions.py
+  DESTINATION ${CATKIN_PACKAGE_BIN_DESTINATION}
+)
+
+install(DIRECTORY launch scripts
+       DESTINATION ${CATKIN_PACKAGE_SHARE_DESTINATION}
+)

--- a/package.xml
+++ b/package.xml
@@ -28,7 +28,11 @@
   <run_depend>tf</run_depend>
   <run_depend>visualization_msgs</run_depend>
   <run_depend>message_runtime</run_depend>
-
+  <run_depend>gmapping</run_depend>
+  <run_depend>navigation</run_depend>
+  <run_depend>python-opencv</run_depend>
+  <run_depend>python-numpy</run_depend>
+  <run_depend>python-sklearn</run_depend>
 
   <!-- The export tag contains other, unspecified, tags -->
   <export>

--- a/setup.py
+++ b/setup.py
@@ -1,0 +1,11 @@
+## ! DO NOT MANUALLY INVOKE THIS setup.py, USE CATKIN INSTEAD
+
+from distutils.core import setup
+from catkin_pkg.python_setup import generate_distutils_setup
+
+# fetch values from package.xml
+setup_args = generate_distutils_setup(
+    packages=['rrt_exploration'],
+    package_dir={'': 'src'})
+
+setup(**setup_args)


### PR DESCRIPTION
The dependencies are listed in package.xml so they work with `rosdep` and `colcon bundle`. 
The CMakeLists.txt uses `INSTALL()` to support `colcon build` and `colcon bundle`. 

The following steps install dependencies from package.xml, and builds and bundles:
```
rosdep install --from-paths . --ignore-src -r -y
colcon build
colcon bundle
```

After `colcon build`, you source the package locally:
```
source install/setup.sh
```

After `colcon bundle`, the bundle archive is in `bundle/output.tar.gz`.

Note:
- Colcon Bundle is supported by AWS RoboMaker: https://docs.aws.amazon.com/robomaker/latest/dg/application-build-bundle.html
- the README.md has not been updated