### PR TITLE
Fix Indexing Error in Filter.py

### DIFF
--- a/scripts/filter.py
+++ b/scripts/filter.py
@@ -39,7 +39,7 @@ def globalMap(data):
     global1 = data
     if n_robots > 1:
         indx = int(data._connection_header['topic']
-                   [litraIndx])-namespace_init_count
+                   [litraIndx+1])-namespace_init_count
     elif n_robots == 1:
         indx = 0
     globalmaps[indx] = data


### PR DESCRIPTION
When looking for the `global_costmap_topics`, I noticed that it would point towards the wrong index in the topic name thus not pulling down the robot's index number. This solution fixes that by shifting `litraIndx` one to the right.

Original Error
```
[ERROR] [1600985292.579831, 0.000000]: bad callback: <function globalMap at 0x7f3d5ab575d0>
Traceback (most recent call last):
  File "/opt/ros/melodic/lib/python2.7/dist-packages/rospy/topics.py", line 750, in _invoke_callback
    cb(msg)
  File "/home/jmdanie/catkin_ws/src/rrt_exploration/scripts/filter.py", line 45, in globalMap
    [litraIndx])-namespace_init_count
ValueError: invalid literal for int() with base 10: '_'

[ERROR] [1600985292.580379, 0.000000]: bad callback: <function globalMap at 0x7f3d5ab575d0>
Traceback (most recent call last):
  File "/opt/ros/melodic/lib/python2.7/dist-packages/rospy/topics.py", line 750, in _invoke_callback
    cb(msg)
  File "/home/jmdanie/catkin_ws/src/rrt_exploration/scripts/filter.py", line 45, in globalMap
    [litraIndx])-namespace_init_count
ValueError: invalid literal for int() with base 10: '_'
```