### PR TITLE
ROS Noetic Compatibility Changes

### DIFF
--- a/scripts/assigner.py
+++ b/scripts/assigner.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 
 #--------Include modules---------------
 from copy import copy

--- a/scripts/filter.py
+++ b/scripts/filter.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 
 # --------Include modules---------------
 from copy import copy

--- a/scripts/functions.py
+++ b/scripts/functions.py
@@ -100,9 +100,9 @@ def index_of_point(mapData, Xp):
 
 def point_of_index(mapData, i):
     y = mapData.info.origin.position.y + \
-        (i/mapData.info.width)*mapData.info.resolution
+        (i//mapData.info.width)*mapData.info.resolution
     x = mapData.info.origin.position.x + \
-        (i-(i/mapData.info.width)*(mapData.info.width))*mapData.info.resolution
+        (i-(i//mapData.info.width)*(mapData.info.width))*mapData.info.resolution
     return array([x, y])
 # ________________________________________________________________________________
 


### PR DESCRIPTION
These changes make the rrt_exploration package compatible with ROS Noetic

1. Python 3 is the default for ROS1 distributions starting from Noetic. Hence, the shebang has been updated to point at `python3`.
2. Integer division result is different between `python2` and `python3`. For example, 3/2 is 1 in `python2` but 1.5 in `python3`, however, 3//2 is 1 in `python3`.  Hence, the / operator has been replaced with // to get floored integers.